### PR TITLE
add gnupg dependency

### DIFF
--- a/posts/guides/3-web-setup.md
+++ b/posts/guides/3-web-setup.md
@@ -18,7 +18,7 @@ To get the latest **Node.js** and **NPM** version, you can visit the official **
 Or, you can install _Node.js_ and _NPM_ on **Ubuntu** as follows:
 
 ```bash
-sudo apt-get -y install curl
+sudo apt-get -y install curl gnupg
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get -y install nodejs
 ```


### PR DESCRIPTION
When installing on a plain OS (at least on Debian 9), the gnupg package is required for the nodejs installation, so let's add that as dependency.